### PR TITLE
fix: disable Better Auth cookie cache to prevent 1024 char limit warning

### DIFF
--- a/functions/api/utils/db.ts
+++ b/functions/api/utils/db.ts
@@ -55,10 +55,10 @@ export function createAuthForRuntime(env: Env) {
       expiresIn: 604800, // 7日（秒）
       updateAge: 86400,  // 1日（秒）
       cookieCache: {
-        enabled: false, // Cookieサイズ警告解決
-        // enabled: true,    // セッションクッキーキャッシュを有効
-        // maxAge: 300       // 5分
+        enabled: true,    // セッションクッキーキャッシュを有効
+        maxAge: 120       // 2分（短時間でセッション情報更新）
       },
+      // freshAge: 60 * 60 * 24, // デフォルトで1日
       storeSessionInDatabase: true, // データベースにセッション保存
     },
     
@@ -69,7 +69,6 @@ export function createAuthForRuntime(env: Env) {
       },
       useSecureCookies: !isLocalDevelopment, // 本番環境では自動的にtrue
       disableCSRFCheck: false,
-      // cookies 設定を削除してBetter Authのデフォルトを使用
       database: {
         generateId: () => createId(), // CUID2でID生成
       },

--- a/functions/api/utils/db.ts
+++ b/functions/api/utils/db.ts
@@ -56,7 +56,7 @@ export function createAuthForRuntime(env: Env) {
       updateAge: 86400,  // 1日（秒）
       cookieCache: {
         enabled: true,    // セッションクッキーキャッシュを有効
-        maxAge: 120       // 2分（短時間でセッション情報更新）
+        maxAge: 300       // 5分（セッション情報更新）
       },
       // freshAge: 60 * 60 * 24, // デフォルトで1日
       storeSessionInDatabase: true, // データベースにセッション保存

--- a/functions/api/utils/db.ts
+++ b/functions/api/utils/db.ts
@@ -55,8 +55,9 @@ export function createAuthForRuntime(env: Env) {
       expiresIn: 604800, // 7日（秒）
       updateAge: 86400,  // 1日（秒）
       cookieCache: {
-        enabled: true,    // セッションクッキーキャッシュを有効
-        maxAge: 300       // 5分
+        enabled: false, // Cookieサイズ警告解決
+        // enabled: true,    // セッションクッキーキャッシュを有効
+        // maxAge: 300       // 5分
       },
       storeSessionInDatabase: true, // データベースにセッション保存
     },


### PR DESCRIPTION
# 🔧 Fix: Better Auth cookie size limit warning

## 📋 概要

Better Authのセッションクッキーが1024文字制限を超える際の警告を解決。

## 🐛 問題

長いユーザー名（30文字以上）でログインした際、ブラウザコンソールに以下の警告が表示された：

```
Cookie attribute values exceeding 1024 characters in size will result in the attribute being ignored. 
This could lead to unexpected behavior since the cookie will be processed as if the offending attribute / attribute value pair were not present.
```

**発生条件**:
- ユーザー名: `とてもとても長い長いユーザー名のテストユーザー18` (約36文字)
- Cookie名: `better-auth.session_token`

## 🔍 原因

Better Authの`cookieCache`機能により、セッション情報（ユーザー名、メール、メタデータ等）がクッキーに保存され、1024文字制限を超過していた。

## ✅ 解決方法

`functions/api/utils/db.ts`のBetter Auth設定を修正：

```typescript
session: {
  expiresIn: 604800, // 7日（秒）
  updateAge: 86400,  // 1日（秒）
  cookieCache: {
    enabled: false,   // 🔧 無効化（データベースから毎回取得）
  },
  storeSessionInDatabase: true,
},
```

## 🧪 テスト結果

**修正前**:
- ✅ 短いユーザー名: 正常動作
- ❌ 長いユーザー名: Cookie警告発生

**修正後**:
- ✅ 短いユーザー名: 正常動作
- ✅ 長いユーザー名: 警告なし、正常動作

## ⚠️ プレビュー環境でエラー
- Cookieキャッシュ無効化すると、プレビュー環境で認証機能が動作しなくなる。
- 現在の本番環境・一つ前のプレビュー環境（ともにCookieキャッシュ5分設定）では警告が出なくなっていることを確認

## 📊 検証結果

### 開発・プレビュー・本番それぞれのデータベースの session テーブルの状態を確認
- 開発：36
- プレビュー：3
- 本番：4

### 開発用データベースの session テーブルを空にしてテスト
**Cookieキャッシュ無効設定**
- ✅ 短いユーザー名: 正常動作
- ✅ 長いユーザー名: 警告なし、正常動作

**Cookieキャッシュ2分設定**
- ✅ 短いユーザー名: 正常動作
- ❌ 長いユーザー名: Cookie警告発生(ページリロードで警告は消える）

### **問題の特定**
Cookie警告は長いユーザー名使用時に一時的に発生。
セッション蓄積との関連性も確認されたが、
より根本的にはユーザー名長制限が必要。

## **現在の解決策**
~~2分キャッシュで安定性と警告軽減を両立。~~
2分だと Cloudflare のプレビュー環境のリソース制限に引っかかるため、5分キャッシュ設定に戻す
（安定動作優先と作業コストを考慮）

## **将来の根本解決**
Issue #4でユーザー名文字数制限（Zod）を実装予定。